### PR TITLE
Added dark theme, option to en/disable lint, added append text for JSON editor

### DIFF
--- a/sapl-editor-for-vaadin/README.md
+++ b/sapl-editor-for-vaadin/README.md
@@ -8,7 +8,7 @@ The usage of this component requires at least Java 11.
 
 ### Vaadin 14 Web Application
 
-The text editors are implemented as addons for a Vaadin 14 application. As such it is required that the target application uses at least a Vaadin 14. 
+The text editors are implemented as addons for a Vaadin 14 application. As such it is required that the target application uses at least Vaadin 14. 
 
 For a quick start the base application Vaadin Flow Quick Start can be used:
 
@@ -23,7 +23,7 @@ For Maven it will look like this:
 <dependency>
     <groupId>io.sapl</groupId>
     <artifactId>sapl-editor-for-vaadin</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 </dependency>
 ```
 
@@ -112,11 +112,15 @@ Upon creation of the editor it can be configured with the configuration object, 
 
 * `hasLineNumbers` - Whether or not to display lineNumbers in the editor
 * `textUpdateDelay` - The delay between the user stopped typing and the editor validating the inputed text
+* `setDarkTheme` - Whether or not to enable dark theme of the editor
+* `setLint` - Whether or not to enable linting
 
 ```java
 SaplEditorConfiguration saplConfig = new SaplEditorConfiguration();
 saplConfig.setHasLineNumbers(true);
 saplConfig.setTextUpdateDelay(500);
+saplConfig.setDarkTheme(true);
+saplConfig.setLint(false);
 
 saplEditor = new SaplEditor(saplConfig);
 ```
@@ -128,6 +132,15 @@ The current document can be set or get via the setter and getter of the editor.
 ```java
 saplEditor.setDocument("policy \"set by Vaadin View after instantiation ->\\u2588<-\" permit");
 String document = saplEditor.getDocument();
+```
+
+### Dark Theme
+
+The theme of the editor can be changed at runtime. Whether the dark theme is enabled or not can be checked via the getter of the editor.
+
+```java
+saplEditor.setDarkTheme(true);
+Boolean isDarkThemeEnabled = saplEditor.isDarkTheme();
 ```
 
 ### DocumentChangedListener
@@ -242,11 +255,15 @@ Upon creation of the editor it can be configured with the configuration object, 
 
 * `hasLineNumbers` - Whether or not to display lineNumbers in the editor
 * `textUpdateDelay` - The delay between the user stopped typing and the editor validating the inputed text
+* `setDarkTheme` - Whether or not to enable dark theme of the editor
+* `setLint` - Whether or not to enable linting
 
 ```java
 JsonEditorConfiguration jsonEditorConfig = new JsonEditorConfiguration();
 jsonEditorConfig.setHasLineNumbers(true);
 jsonEditorConfig.setTextUpdateDelay(500);
+jsonEditorConfig.setDarkTheme(true);
+jsonEditorConfig.setLint(false);
 
 JsonEditor jsonEditor = new JsonEditor(jsonEditorConfig);
 add(jsonEditor)
@@ -281,6 +298,23 @@ jsonEditor.setDocument("[\r\n"
 String document = jsonEditor.getDocument();
 ```
 
+### Dark Theme
+
+The theme of the editor can be changed at runtime. Whether the dark theme is enabled or not can be checked via the getter of the editor.
+
+```java
+jsonEditor.setDarkTheme(true);
+Boolean isDarkThemeEnabled = jsonEditor.isDarkTheme();
+```
+
+### Linting
+
+Linting can be enabled and disabled at runtime. Whether linting is enabled or not can be checked via the getter of the editor.
+
+```java
+jsonEditor.setLint(false);
+Boolean isLintEnabled = jsonEditor.isLint();
+```
 
 ### DocumentChangedListener
 

--- a/sapl-editor-for-vaadin/src/main/java/io/sapl/vaadin/BaseEditor.java
+++ b/sapl-editor-for-vaadin/src/main/java/io/sapl/vaadin/BaseEditor.java
@@ -21,6 +21,7 @@ import java.util.List;
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.dom.Element;
+import io.sapl.api.validation.Bool;
 
 public class BaseEditor extends Component {
 
@@ -39,6 +40,8 @@ public class BaseEditor extends Component {
 		element.setProperty("matchBrackets", config.isMatchBrackets());
 		element.setProperty("textUpdateDelay", config.getTextUpdateDelay());
 		element.setProperty(IsReadOnlyKey, config.isReadOnly());
+		element.setProperty("isLint", config.isLint());
+		element.setProperty("isDarkTheme", config.isDarkTheme());
     }
 
     @ClientCallable
@@ -87,14 +90,62 @@ public class BaseEditor extends Component {
 	public void removeDocumentChangedListener(DocumentChangedListener listener) {
 		this.documentChangedListeners.remove(listener);
 	}
-	
+
+	/**
+	 * This function enables or disables the read-only mode of the editor.
+	 *
+	 * @param isReadOnly
+	 */
 	public void setReadOnly(Boolean isReadOnly) {
 		Element element = getElement();
 		element.setProperty(IsReadOnlyKey, isReadOnly);
 	}
-	
+
+	/**
+	 * This function returns the current read-only status of the editor.
+	 *
+	 * @return The current read-only as a Boolean.
+	 */
 	public Boolean isReadOnly() {
 		Element element = getElement();
 		return element.getProperty(IsReadOnlyKey, false);
+	}
+
+	/**
+	 * If this function is called the editor scrolls to the bottom of the textarea.
+	 */
+	public void scrollToBottom() {
+		Element element = getElement();
+		element.callJsFunction("scrollToBottom");
+	}
+
+	/**
+	 * This function enables or disables the Dark Theme of the editor.
+	 *
+	 * @param isDarkTheme
+	 */
+	public void setDarkTheme(Boolean isDarkTheme) {
+		Element element = getElement();
+		element.setProperty("isDarkTheme", isDarkTheme);
+	}
+
+	/**
+	 * This function returns a Boolean to whether the editor uses the Dark Theme or not.
+	 *
+	 * @return Enabled or disabled Dark Theme as a Boolean.
+	 */
+	public Boolean isDarkTheme() {
+		Element element = getElement();
+		return element.getProperty("isDarkTheme", false);
+	}
+
+	/**
+	 * This function returns a Boolean whether if the editor has linting enabled or not.
+	 *
+	 * @return Enabled or disabled lint as a Boolean.
+	 */
+	public Boolean isLint() {
+		Element element = getElement();
+		return element.getProperty("isLint", true);
 	}
 }

--- a/sapl-editor-for-vaadin/src/main/java/io/sapl/vaadin/BaseEditor.java
+++ b/sapl-editor-for-vaadin/src/main/java/io/sapl/vaadin/BaseEditor.java
@@ -15,13 +15,12 @@
  */
 package io.sapl.vaadin;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.dom.Element;
-import io.sapl.api.validation.Bool;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class BaseEditor extends Component {
 

--- a/sapl-editor-for-vaadin/src/main/java/io/sapl/vaadin/BaseEditorConfiguration.java
+++ b/sapl-editor-for-vaadin/src/main/java/io/sapl/vaadin/BaseEditorConfiguration.java
@@ -27,4 +27,6 @@ public class BaseEditorConfiguration {
 	private boolean matchBrackets = true;
 	private int textUpdateDelay = 500;
 	private boolean readOnly = false;
+	private boolean lint = true;
+	private boolean darkTheme = false;
 }

--- a/sapl-editor-for-vaadin/src/main/java/io/sapl/vaadin/JsonEditor.java
+++ b/sapl-editor-for-vaadin/src/main/java/io/sapl/vaadin/JsonEditor.java
@@ -36,4 +36,15 @@ public class JsonEditor extends BaseEditor {
 		Element element = getElement();
 		element.callJsFunction("onRefreshEditor");
 	}
+
+	public void appendText(String text) {
+		Element element = getElement();
+		element.callJsFunction("appendText", text);
+	}
+
+	public void setLint(Boolean isLint) {
+		Element element = getElement();
+		element.setProperty("isLint", isLint);
+	}
+
 }

--- a/sapl-editor-for-vaadin/src/main/resources/META-INF/frontend/json-editor.js
+++ b/sapl-editor-for-vaadin/src/main/resources/META-INF/frontend/json-editor.js
@@ -1,5 +1,5 @@
 import { LitElement, html } from 'lit-element';
-import { CodeMirrorStyles, CodeMirrorLintStyles, CodeMirrorHintStyles, HeightFix, ReadOnlyStyle } from './shared-styles.js';
+import { CodeMirrorStyles, CodeMirrorLintStyles, CodeMirrorHintStyles, HeightFix, ReadOnlyStyle, DarkStyle } from './shared-styles.js';
 import * as codemirror from 'codemirror';
 import 'codemirror/mode/javascript/javascript';
 import 'codemirror/addon/lint/lint';
@@ -16,12 +16,14 @@ class JSONEditor extends LitElement {
   static get properties() {
     return {
       document: { type: String },
-      isReadOnly: { type: Boolean }, 
+      isReadOnly: { type: Boolean },
       hasLineNumbers: { type: Boolean },
       autoCloseBrackets: { type: Boolean },
       matchBrackets: { type: Boolean },
       textUpdateDelay: { type: Number },
       editor: { type: Object },
+      isLint: { type: Boolean },
+      isDarkTheme: { type: Boolean }
     }
   }
 
@@ -32,6 +34,7 @@ class JSONEditor extends LitElement {
       CodeMirrorHintStyles,
       HeightFix,
       ReadOnlyStyle,
+      DarkStyle
     ]
   }
 
@@ -55,8 +58,32 @@ class JSONEditor extends LitElement {
     this.setEditorOption('readOnly', value);
   }
 
-  get isReadOnly() { 
-    return this._isReadOnly; 
+  get isReadOnly() {
+    return this._isReadOnly;
+  }
+
+  set isLint(value) {
+    let oldVal = this._isLint;
+    this._isLint = value;
+    console.debug('JsonEditor: set isLint', oldVal, value);
+    this.requestUpdate("isLint", oldVal);
+    this.setLintEditorOption(value);
+  }
+
+  get isLint() {
+    return this._isLint;
+  }
+
+  set isDarkTheme(value) {
+    let oldVal = this._isDarkTheme;
+    this._isDarkTheme = value;
+    console.debug('JsonEditor: set isDarkTheme', oldVal, value);
+    this.requestUpdate("isDarkTheme", oldVal);
+    this.setDarkThemeEditorOption(value);
+  }
+
+  get isDarkTheme() {
+    return this._isDarkTheme;
   }
 
   firstUpdated(changedProperties) {
@@ -75,6 +102,7 @@ class JSONEditor extends LitElement {
       lint: {
         selfContain: true
       },
+      theme: "default"
     });
 
     self.editor.on("change", function(cm, changeObj) {
@@ -123,6 +151,8 @@ class JSONEditor extends LitElement {
 
     if(isEditorSet) {
       this.setEditorOption('readOnly', this.isReadOnly);
+      this.setDarkThemeEditorOption(this.isDarkTheme);
+      this.setLintEditorOption(this.isLint);
     }
   }
 
@@ -140,6 +170,52 @@ class JSONEditor extends LitElement {
   render() {
     return html``;
   }
+
+  scrollToBottom() {
+    let isEditorSet = this.editor !== undefined;
+    console.debug('JsonEditor: scrollToBottom', isEditorSet);
+
+    let scrollInfo = this.editor.getScrollInfo();
+    if(isEditorSet) {
+      this.editor.scrollTo(null, scrollInfo.height);
+    }
+  }
+
+  appendText(text) {
+    let isEditorSet = this.editor !== undefined;
+    console.debug('JsonEditor: appendText', isEditorSet);
+    if(isEditorSet) {
+      let lines = this.editor.lineCount();
+      this.editor.replaceRange(text + "\n", {line: lines});
+    }
+  }
+
+  setDarkThemeEditorOption(value) {
+    console.debug('JsonEditor: setDarkThemeEditorOption', value);
+    let isEditorSet = this.editor !== undefined;
+    if(isEditorSet) {
+      if(value === true) {
+        this.editor.setOption("theme", 'dracula');
+      } else {
+        // Needed to not overwrite readonly Theme
+        this.setEditorOption('readOnly', this._isReadOnly);
+      }
+    }
+  }
+
+  setLintEditorOption(value) {
+    console.debug('JsonEditor: setLintOption', value);
+    let isEditorSet = this.editor !== undefined;
+    if(isEditorSet) {
+      if(value === true) {
+        this.editor.setOption("lint", {selfContain: true});
+      }
+      else if (value === false) {
+        this.editor.setOption("lint", false);
+      }
+    }
+  }
+
 }
 
 customElements.define('json-editor', JSONEditor);

--- a/sapl-editor-for-vaadin/src/main/resources/META-INF/frontend/shared-styles.js
+++ b/sapl-editor-for-vaadin/src/main/resources/META-INF/frontend/shared-styles.js
@@ -585,3 +585,38 @@ export const ReadOnlyStyle = css`
 .cm-s-readOnly .cm-quote {color: #090;}
 .cm-s-readOnly .cm-error {color: #f00;}
 `
+
+export const DarkStyle = css`
+.cm-s-dracula.CodeMirror, .cm-s-dracula .CodeMirror-gutters {
+  background-color: #282a36 !important;
+  color: #f8f8f2 !important;
+  border: none;
+}
+.cm-s-dracula .CodeMirror-gutters { color: #282a36; }
+.cm-s-dracula .CodeMirror-cursor { border-left: solid thin #f8f8f0; }
+.cm-s-dracula .CodeMirror-linenumber { color: #6D8A88; }
+.cm-s-dracula .CodeMirror-selected { background: rgba(255, 255, 255, 0.10); }
+.cm-s-dracula .CodeMirror-line::selection, .cm-s-dracula .CodeMirror-line > span::selection, .cm-s-dracula .CodeMirror-line > span > span::selection { background: rgba(255, 255, 255, 0.10); }
+.cm-s-dracula .CodeMirror-line::-moz-selection, .cm-s-dracula .CodeMirror-line > span::-moz-selection, .cm-s-dracula .CodeMirror-line > span > span::-moz-selection { background: rgba(255, 255, 255, 0.10); }
+.cm-s-dracula span.cm-comment { color: #6272a4; }
+.cm-s-dracula span.cm-string, .cm-s-dracula span.cm-string-2 { color: #f1fa8c; }
+.cm-s-dracula span.cm-number { color: #bd93f9; }
+.cm-s-dracula span.cm-variable { color: #50fa7b; }
+.cm-s-dracula span.cm-variable-2 { color: white; }
+.cm-s-dracula span.cm-def { color: #50fa7b; }
+.cm-s-dracula span.cm-operator { color: #ff79c6; }
+.cm-s-dracula span.cm-keyword { color: #ff79c6; }
+.cm-s-dracula span.cm-atom { color: #bd93f9; }
+.cm-s-dracula span.cm-meta { color: #f8f8f2; }
+.cm-s-dracula span.cm-tag { color: #ff79c6; }
+.cm-s-dracula span.cm-attribute { color: #50fa7b; }
+.cm-s-dracula span.cm-qualifier { color: #50fa7b; }
+.cm-s-dracula span.cm-property { color: #66d9ef; }
+.cm-s-dracula span.cm-builtin { color: #50fa7b; }
+.cm-s-dracula span.cm-variable-3, .cm-s-dracula span.cm-type { color: #ffb86c; }
+
+.cm-s-dracula .CodeMirror-activeline-background { background: rgba(255,255,255,0.1); }
+.cm-s-dracula .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
+
+
+`

--- a/sapl-editor-for-vaadin/src/main/resources/META-INF/frontend/shared-styles.js
+++ b/sapl-editor-for-vaadin/src/main/resources/META-INF/frontend/shared-styles.js
@@ -614,9 +614,6 @@ export const DarkStyle = css`
 .cm-s-dracula span.cm-property { color: #66d9ef; }
 .cm-s-dracula span.cm-builtin { color: #50fa7b; }
 .cm-s-dracula span.cm-variable-3, .cm-s-dracula span.cm-type { color: #ffb86c; }
-
 .cm-s-dracula .CodeMirror-activeline-background { background: rgba(255,255,255,0.1); }
 .cm-s-dracula .CodeMirror-matchingbracket { text-decoration: underline; color: white !important; }
-
-
 `


### PR DESCRIPTION
Added
- Function + CSS to enable and disable the dark theme for JSON and SAPL Editor
- Function to enable and disable lint for JSON and SAPL Editor
- appendText() for JSON Editor to display decisions in NDJSON format
- scrollToBottom() to scroll to the bottom of the JSON editor

- Updated Readme