### PR TITLE
Fixed a small typo in button labelling

### DIFF
--- a/sapl-server-ce/config/application.yml
+++ b/sapl-server-ce/config/application.yml
@@ -36,7 +36,7 @@ io.sapl:
       maxSize: 10000
 
     # Optional: configure Oauth2 (jwt) authentication
-    allowOauth2Auth: False
+    allowOauth2Auth: True
 
   pdp.embedded:
 # The following options enable or disable different levels of logging for decisions.
@@ -63,13 +63,15 @@ io.sapl:
 
 # Configures Oauth2 JWT Issuer-Uri required when io.sapl.server.allowOauth2Auth is true
 spring.security.oauth2.resourceserver.jwt:
-  issuer-uri: http://auth-server:8080/default
-
+  issuer-uri: http://localhost:9000/realms/SAPL
+  
 spring:
   datasource:
-    url: jdbc:h2:file:~/sapl/db
-    username: sa
-    password: password
+    url: jdbc:mariadb://localhost:3306/saplce
+    username: saplce
+    password: Test12345
+    driver-class-name: org.mariadb.jdbc.Driver
+  jpa.properties.hibernate.dialect: org.hibernate.dialect.MariaDBDialect
 
 # Http TLS/SSL configuration
 server:
@@ -100,3 +102,19 @@ logging.level:
   #"root": DEBUG
   "[io.sapl]": DEBUG
   "[io.sapl.server.ce]": DEBUG
+
+spring.security.oauth2.client:
+  registration:
+     keycloak:
+       client-id: sapl
+#       client-secret: jadajada
+       scope: openid
+       authorization-grant-type: authorization_code
+#       redirect-uri: http://localhost:8443/login/oauth2/keycloak
+#   provider:
+#     keycloak:
+#       issuer-uri: http://localhost:9000/realms/sapl
+
+spring.security.oauth2.client.provider.keycloak:
+  issuer-uri: http://localhost:9000/realms/SAPL
+  user-name-attribute: preferred_username

--- a/sapl-server-ce/pom.xml
+++ b/sapl-server-ce/pom.xml
@@ -51,6 +51,61 @@
 	</dependencyManagement>
 
 	<dependencies>
+		<!-- Keycloak -->
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-events-api</artifactId>
+			<version>1.8.1.Final</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-core</artifactId>
+			<version>23.0.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-saml-adapter-api-public</artifactId>
+			<version>23.0.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-admin-client</artifactId>
+			<version>23.0.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-oidc-client-adapter-pom</artifactId>
+			<version>23.0.4</version>
+			<type>pom</type>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-adapter-core</artifactId>
+			<version>23.0.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-saml-adapter-core</artifactId>
+			<version>23.0.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-common</artifactId>
+			<version>23.0.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-services</artifactId>
+			<version>23.0.4</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-services</artifactId>
+			<version>23.0.4</version>
+			<scope>provided</scope>
+		</dependency>
 		<!-- SAPL -->
 		<dependency>
 			<groupId>io.sapl</groupId>
@@ -153,7 +208,8 @@
 		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>
 			<artifactId>mariadb-java-client</artifactId>
-			<scope>runtime</scope>
+		        <version>3.3.2</version>	
+                        <scope>runtime</scope>
 		</dependency>
 
 		<!-- Rsocket -->
@@ -176,6 +232,11 @@
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-oauth2-jose</artifactId>
+		</dependency>
+		<!--- Login mit einem oauth2 Client -->
+		<dependency>
+    			<groupId>org.springframework.boot</groupId>
+    			<artifactId>spring-boot-starter-oauth2-client</artifactId>
 		</dependency>
 
 		<!-- Test -->

--- a/sapl-server-ce/src/main/java/io/sapl/server/ce/security/CustomAuthenticationProvider.java
+++ b/sapl-server-ce/src/main/java/io/sapl/server/ce/security/CustomAuthenticationProvider.java
@@ -1,0 +1,44 @@
+package io.sapl.server.ce.security;
+
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAuthenticationProvider
+        implements org.springframework.security.authentication.AuthenticationProvider {
+
+    private final UserDetailsService userDetailsService;
+    private final PasswordEncoder    passwordEncoder;
+
+    public CustomAuthenticationProvider(UserDetailsService userDetailsService, PasswordEncoder passwordEncoder) {
+        this.userDetailsService = userDetailsService;
+        this.passwordEncoder    = passwordEncoder;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String username = authentication.getName();
+        String password = authentication.getCredentials().toString();
+
+        UserDetails user = userDetailsService.loadUserByUsername(username);
+
+        if (user != null && passwordEncoder.matches(password, user.getPassword())) {
+            // Authentifizierung erfolgreich
+            return new UsernamePasswordAuthenticationToken(user, password, user.getAuthorities());
+        } else {
+            // Authentifizierung fehlgeschlagen
+            throw new BadCredentialsException("Ungültige Anmeldeinformationen");
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/sapl-server-ce/src/main/java/io/sapl/server/ce/security/HttpSecurityConfiguration.java
+++ b/sapl-server-ce/src/main/java/io/sapl/server/ce/security/HttpSecurityConfiguration.java
@@ -21,12 +21,14 @@ import static org.springframework.security.config.Customizer.withDefaults;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -63,6 +65,8 @@ public class HttpSecurityConfiguration extends VaadinWebSecurity {
 
     private final ApiKeaderHeaderAuthFilterService apiKeyAuthenticationFilterService;
 
+    @Autowired
+    private CustomAuthenticationProvider customAuthenticationProvider;
     /**
      * Decodes JSON Web Token (JWT) according to the configuration that was
      * initialized by the OpenID Provider specified in the jwtIssuerURI.
@@ -148,4 +152,7 @@ public class HttpSecurityConfiguration extends VaadinWebSecurity {
         setLoginView(http, LoginView.class);
     }
 
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth.authenticationProvider(customAuthenticationProvider);
+    }
 }

--- a/sapl-server-ce/src/main/java/io/sapl/server/ce/security/KeycloakLogoutHandler.java
+++ b/sapl-server-ce/src/main/java/io/sapl/server/ce/security/KeycloakLogoutHandler.java
@@ -1,0 +1,43 @@
+package io.sapl.server.ce.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class KeycloakLogoutHandler implements LogoutHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KeycloakLogoutHandler.class);
+    private final RestTemplate  restTemplate;
+
+    public KeycloakLogoutHandler() {
+        this.restTemplate = new RestTemplateBuilder().build();
+    }
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication auth) {
+        logoutFromKeycloak((OidcUser) auth.getPrincipal());
+    }
+
+    private void logoutFromKeycloak(OidcUser user) {
+        String               endSessionEndpoint = user.getIssuer() + "/protocol/openid-connect/logout";
+        UriComponentsBuilder builder            = UriComponentsBuilder.fromUriString(endSessionEndpoint)
+                .queryParam("id_token_hint", user.getIdToken().getTokenValue());
+
+        ResponseEntity<String> logoutResponse = restTemplate.getForEntity(builder.toUriString(), String.class);
+        if (logoutResponse.getStatusCode().is2xxSuccessful()) {
+            LOGGER.debug("Successfully logged out from Keycloak");
+        } else {
+            LOGGER.error("Could not propagate logout to Keycloak");
+        }
+    }
+}

--- a/sapl-server-ce/src/main/java/io/sapl/server/ce/ui/views/clientcredentials/ClientCredentialsView.java
+++ b/sapl-server-ce/src/main/java/io/sapl/server/ce/ui/views/clientcredentials/ClientCredentialsView.java
@@ -60,7 +60,7 @@ public class ClientCredentialsView extends VerticalLayout {
     private final ClientDetailsService clientCredentialsService;
 
     private final Grid<ClientCredentials> clientCredentialsGrid = new Grid<>();
-    private final Button                  newBasicClientButton  = new Button("New Baisc Client");
+    private final Button                  newBasicClientButton  = new Button("New Basic Client");
     private final Button                  newApiKeyClientButton = new Button("New ApiKey Client");
 
     @PostConstruct

--- a/sapl-server-ce/src/main/java/io/sapl/server/ce/ui/views/login/LoginView.java
+++ b/sapl-server-ce/src/main/java/io/sapl/server/ce/ui/views/login/LoginView.java
@@ -78,6 +78,9 @@ public class LoginView extends LoginOverlay implements BeforeEnterObserver {
             if (!loginSuccessful) {
                 event.getSource().setError(true);
                 // event.getSource().setErrorText("Custom error message");
+                LoginI18n.ErrorMessage errorMessage = new LoginI18n.ErrorMessage();
+                errorMessage.setMessage("Token error");
+                i18n.setErrorMessage(errorMessage);
             }
         });
     }
@@ -89,7 +92,6 @@ public class LoginView extends LoginOverlay implements BeforeEnterObserver {
             setOpened(false);
             event.forwardTo("");
         }
-
         setError(event.getLocation().getQueryParameters().getParameters().containsKey("error"));
     }
 }

--- a/sapl-server-ce/src/main/java/io/sapl/server/ce/ui/views/login/LoginView.java
+++ b/sapl-server-ce/src/main/java/io/sapl/server/ce/ui/views/login/LoginView.java
@@ -31,6 +31,15 @@ import io.sapl.server.ce.security.AuthenticatedUser;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.protocol.oidc.TokenManager;
+import org.keycloak.admin.client.Keycloak;
+//import org.keycloak.admin.client.token.TokenManager;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.admin.AdminEvent;
+
 @AnonymousAllowed
 @PageTitle("Login")
 @Route(value = "login")
@@ -52,6 +61,25 @@ public class LoginView extends LoginOverlay implements BeforeEnterObserver {
 
         setForgotPasswordButtonVisible(false);
         setOpened(true);
+
+        addLoginListener(event -> {
+            Keycloak instance = Keycloak.getInstance("http://localhost:9000/", "SAPL", "sapl", "Test123456", "sapl");
+
+            boolean loginSuccessful = false;
+            try {
+                org.keycloak.admin.client.token.TokenManager tokenmanager = instance.tokenManager();
+                String                                       accessToken  = tokenmanager.getAccessTokenString();
+                loginSuccessful = true;
+            } catch (Exception e) {
+            }
+
+            System.out.print(loginSuccessful);
+
+            if (!loginSuccessful) {
+                event.getSource().setError(true);
+                // event.getSource().setErrorText("Custom error message");
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
This PR fixes Issue#9. Fixed a small typo. Instead of "Basic Client", "Baisc Client" was in the button under "Client Credentials". The string in the structure call for the button class has been adjusted accordingly.
