### PR TITLE
Set text fields to read only in EditSaplDocumentView

### DIFF
--- a/sapl-server-ce/src/main/java/io/sapl/server/ce/ui/views/digitalpolicies/EditSaplDocumentView.java
+++ b/sapl-server-ce/src/main/java/io/sapl/server/ce/ui/views/digitalpolicies/EditSaplDocumentView.java
@@ -92,7 +92,8 @@ public class EditSaplDocumentView extends VerticalLayout implements HasUrlParame
         var metadataRowOne   = new HorizontalLayout(policyIdField, currentVersionField, lastModifiedField);
         var metadataRowTwo   = new HorizontalLayout(publishedVersionField, publishedNameField);
         var metadataRowThree = new HorizontalLayout(versionSelection, publishButton, unpublishButton);
-        var editActionsRow   = new HorizontalLayout(saveVersionButton, cancelButton);
+        metadataRowThree.setAlignItems(Alignment.BASELINE);
+        var editActionsRow = new HorizontalLayout(saveVersionButton, cancelButton);
         editActionsRow.setWidthFull();
         editActionsRow.setJustifyContentMode(JustifyContentMode.END);
         add(metadataRowOne, metadataRowTwo, metadataRowThree, saplEditor, editActionsRow);
@@ -190,8 +191,11 @@ public class EditSaplDocumentView extends VerticalLayout implements HasUrlParame
      */
     private void setUI() {
         policyIdField.setValue(saplDocument.getId().toString());
+        policyIdField.setReadOnly(true);
         lastModifiedField.setValue(saplDocument.getLastModified());
+        lastModifiedField.setReadOnly(true);
         currentVersionField.setValue(Integer.toString(saplDocument.getCurrentVersionNumber()));
+        currentVersionField.setReadOnly(true);
 
         Collection<String> availableVersions = getAvailableVersions();
         versionSelection.setItems(availableVersions);
@@ -233,7 +237,9 @@ public class EditSaplDocumentView extends VerticalLayout implements HasUrlParame
         }
 
         publishedVersionField.setValue(publishedVersionAsString);
+        publishedVersionField.setReadOnly(true);
         publishedNameField.setValue(publishedNameAsString);
+        publishedNameField.setReadOnly(true);
 
         unpublishButton.setEnabled(isPublishedVersionExisting);
     }


### PR DESCRIPTION
@marcbaitinger and I found the text fields in EditSaplDocumentView while checking the input options on the application. In our opinion, no input is necessary there. The pull request sets the text fields to read only.

before
![SAPLServerCEEdit_old](https://github.com/heutelbeck/sapl-server/assets/35935077/738766cb-5189-47c4-bbe4-6d48daa16126)

after
![SAPLServerCEEdit_new](https://github.com/heutelbeck/sapl-server/assets/35935077/f3da668e-aeea-4a41-94ce-63aba3b839fe)
