### PR TITLE
update build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,36 +1,140 @@
-name: build
+
+# Copyright © 2017-2024 Dominic Heutelbeck (dominic@heutelbeck.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Testing and Publishing
 
 on:
   workflow_dispatch:
   push:
-    branches: [main]
-  repository_dispatch:
-    branches: [main]
-  
+    branches:
+      - '**'
+    paths-ignore:
+      - '.github/workflows/**'
+      - '!.github/workflows/build.yml'
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/**'
+      - '!.github/workflows/build.yml'
+      - '**.md'
+
+permissions:
+  contents: read
+
 jobs:
   build:
+    strategy:
+      matrix:
+        java: [ '17']
+        os: [ubuntu-latest]
+      fail-fast: false
+    name: Build (JDK ${{ matrix.java }} on ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      actions: write # for Mattraks/delete-workflow-runs
+      checks: write # for scacap/action-surefire-report to publish result as PR check
+    timeout-minutes: 45
 
-    runs-on: ubuntu-latest
- 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+      with:
+        egress-policy: audit
+
     - name: Check out
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         lfs: true
         fetch-depth: 0
-        
-    - name: Set up JDK 17
+
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
       with:
-        distribution: 'adopt'
-        java-version: 17
+        distribution: temurin
+        java-version: ${{ matrix.java }}
         cache: 'maven'
-       
-    - name: Build with Maven (JUnit, JaCoCo, Sonar) 
-      run: mvn -B org.jacoco:jacoco-maven-plugin:prepare-agent package org.jacoco:jacoco-maven-plugin:report org.sonarsource.scanner.maven:sonar-maven-plugin:RELEASE:sonar -Dsonar.host.url=https://sonar.ftk.de -Dsonar.login=${{ secrets.SONAR_TOKEN }} -P production
 
-    - name: Build SAPL Server CE Docker image
+    - name: Run Tests
+      # Tests: spotbugs
+      run: mvn -U -B verify -fae spotbugs:spotbugs -Pspotbugs -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+
+    - name: Cache Sonar Packages
+      if: ${{ !github.event.pull_request.head.repo.fork && (matrix.os == 'ubuntu-latest') && (matrix.java == '17') && (github.actor != 'dependabot[bot]') }}
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+      with:
+        path: ~/.sonar/cache
+        key: ${{ runner.os }}-sonar
+        restore-keys: ${{ runner.os }}-sonar
+
+    - name: Run SonarCloud Analysis
+      # Not allowed for PRs from forks and from Dependabot. Secrets are not accessible
+      # (see: https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544).
+      if: ${{ !github.event.pull_request.head.repo.fork && (github.actor != 'dependabot[bot]') }}
+      env:
+        SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+      run: >
+        mvn -B sonar:sonar
+        -'Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
+        -Dsonar.organization=heutelbeck
+        -Dsonar.host.url=https://sonarcloud.io
+        -Dsonar.projectKey=heutelbeck_sapl-server
+        -Dsonar.java.spotbugs.reportPaths=target/spotbugsXml.xml
+        -Dsonar.qualitygate.wait=true
+
+    - name: Save PR Number # needed for subsequent SonarCloud workflow for PRs from fork
+      if: ${{ github.event.pull_request.head.repo.fork }}
+      run: echo "${{ github.event.number }}" > pr_data.txt
+
+    - name: Upload Artifact # needed for subsequent SonarCloud workflow for PRs from fork
+      if: ${{ github.event.pull_request.head.repo.fork }}
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+      with:
+        name: pr_build
+        path: |
+          **/src
+          **/target/spotbugsXml.xml
+          **/target/classes
+          **/target/test-classes
+          **/target/site/jacoco/jacoco.xml
+          **/pom.xml
+          pom.xml
+          pr_data.txt
+          .git
+        retention-days: 1
+
+    - name: Build and Publish SAPL Server CE Docker Image
+      if: ${{ github.ref == 'refs/heads/master' }}
       run: mvn -B clean spring-boot:build-image -pl sapl-server-ce -P docker,production -DskipTests -Dspring-boot.build-image.publish=true -Ddocker.credentials.username=${{ secrets.GHUB_USERNAME }} -Ddocker.credentials.password=${{ secrets.GHUB_ACCESS_TOKEN }}
-                 
-    - name: Clean up local repository before caching
-      run: rm -rf /.m2/repository/io/sapl
+
+# This step an be activated as soon as unit tests exist.
+#    - name: Publish Test Report
+#      # Not allowed for PRs from forks and from Dependabot. The GITHUB_TOKEN stays read-only
+#      # (see: https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544).
+#      if: ${{ (success() || failure()) && !github.event.pull_request.head.repo.fork && (github.actor != 'dependabot[bot]') }}
+#      uses: scacap/action-surefire-report@a2911bd1a4412ec18dde2d93b1758b3e56d2a880 # v1.8.0
+
+    - name: Delete Workflow Runs
+      # Not allowed for PRs from forks and from Dependabot. The GITHUB_TOKEN stays read-only
+      # (see: https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544).
+      if: ${{ !github.event.pull_request.head.repo.fork && (github.actor != 'dependabot[bot]') }}
+      uses: Mattraks/delete-workflow-runs@39f0bbed25d76b34de5594dceab824811479e5de # v2.0.6
+      with:
+        token: ${{ github.token }}
+        repository: ${{ github.repository }}
+        retain_days: 1
+        keep_minimum_runs: 6
+
+    - name: Clean up Local Repository before Caching
+      run: rm -rf ~/.m2/repository/io/sapl

--- a/.github/workflows/sonar_analysis_fork.yaml
+++ b/.github/workflows/sonar_analysis_fork.yaml
@@ -1,0 +1,71 @@
+#
+# Copyright © 2017-2024 Dominic Heutelbeck (dominic@heutelbeck.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: SonarCloud Analysis for PRs from Fork
+on:
+  workflow_run:
+    workflows: [Testing and Publishing]
+    types:
+      - completed
+
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
+jobs:
+  analyze:
+    if: ${{ github.event.workflow_run.head_repository.fork && (github.event.workflow_run.conclusion == 'success') }}
+    name: SonarCloud Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+      with:
+        egress-policy: audit
+
+    - name: Download Artifact
+      uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
+      with:
+        name: pr_build
+        github-token: ${{ secrets.GHUB_ACCESS_TOKEN }}
+        run-id: ${{ github.event.workflow_run.id }}
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
+      with:
+        distribution: temurin
+        java-version: 17
+        cache: 'maven'
+
+    - name: Get PR Number
+      run: echo "PR=$(cat pr_data.txt)" >> $GITHUB_ENV
+
+    - name: Analyze with SonarCloud
+      env:
+        SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+      run: >
+        mvn -B sonar:sonar
+        -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+        -Dsonar.host.url=https://sonarcloud.io
+        -Dsonar.organization=heutelbeck
+        -Dsonar.projectKey=heutelbeck_sapl-server
+        -Dsonar.java.spotbugs.reportPaths=target/spotbugsXml.xml
+        -Dsonar.pullrequest.key=${PR}
+        -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+
+    - name: Clean up Local Repository before Caching
+      run: rm -rf /.m2/repository/io/sapl

--- a/sapl-server-ce/pom.xml
+++ b/sapl-server-ce/pom.xml
@@ -36,6 +36,10 @@
 
 	<properties>
 		<spring.profile.from.maven>default</spring.profile.from.maven>
+		<sonar.version>3.9.1.2184</sonar.version>
+		<jacoco.version>0.8.11</jacoco.version>
+		<spotbugs.version>4.7.3.6</spotbugs.version>
+		<sbcontrib.version>7.6.0</sbcontrib.version>
 	</properties>
 	
 	<dependencyManagement>
@@ -293,6 +297,51 @@
 					</filesets>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.sonarsource.scanner.maven</groupId>
+				<artifactId>sonar-maven-plugin</artifactId>
+				<version>${sonar.version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.6.3</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<verbose>false</verbose>
+					<failOnWarnings>true</failOnWarnings>
+					<doclint>none</doclint>
+					<tags>
+						<tag>
+							<name>generated</name>
+							<placement>a</placement>
+							<head>Generated Code</head>
+						</tag>
+						<tag>
+							<name>ordered</name>
+							<placement>a</placement>
+							<head>EMF Ordered</head>
+						</tag>
+						<tag>
+							<name>model</name>
+							<placement>a</placement>
+							<head>EMF Model</head>
+						</tag>
+						<tag>
+							<name>returns</name>
+							<placement>a</placement>
+							<head>EMF Returns:</head>
+						</tag>
+					</tags>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
@@ -379,6 +428,61 @@
 						<configuration>
 							<trimStackTrace>false</trimStackTrace>
 							<enableAssertions>true</enableAssertions>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>coverage</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<version>${jacoco.version}</version>
+						<executions>
+							<execution>
+								<id>prepare-agent</id>
+								<goals>
+									<goal>prepare-agent</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>report</id>
+								<goals>
+									<goal>report</goal>
+								</goals>
+								<configuration>
+									<formats>
+										<format>XML</format>
+									</formats>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>spotbugs</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.spotbugs</groupId>
+						<artifactId>spotbugs-maven-plugin</artifactId>
+						<version>${spotbugs.version}</version>
+						<configuration>
+							<excludeFilterFile>spotbugsExcludeFilter.xml</excludeFilterFile>
+							<!-- There are no test classes at the moment
+							<includeTests>true</includeTests> -->
+							<plugins>
+								<plugin>
+									<groupId>com.mebigfatguy.sb-contrib</groupId>
+									<artifactId>sb-contrib</artifactId>
+									<version>${sbcontrib.version}</version>
+								</plugin>
+							</plugins>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/spotbugsExcludeFilter.xml
+++ b/spotbugsExcludeFilter.xml
@@ -1,0 +1,88 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    Copyright (C) 2023 Dominic Heutelbeck (dominic@heutelbeck.com)
+
+    SPDX-License-Identifier: Apache-2.0
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<FindBugsFilter
+	xmlns="https://github.com/spotbugs/filter/3.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+	<!-- The following rules are excluded from the spotbugs analysis. -->
+	<Match>
+		<Or>
+			<Bug pattern="FII_USE_METHOD_REFERENCE" />
+			<Bug pattern="IMC_IMMATURE_CLASS_VAR_NAME" />
+			<Bug pattern="SPP_PASSING_THIS_AS_PARM" />
+			<Bug pattern="WI_WIRING_OF_STATIC_FIELD" />
+			<Bug pattern="AKI_SUPERFLUOUS_ROUTE_SPECIFICATION" />
+			<Bug pattern="AFBR_ABNORMAL_FINALLY_BLOCK_RETURN" />
+			<Bug pattern="ENMI_EQUALS_ON_ENUM" />
+			<Bug pattern="IMC_IMMATURE_CLASS_BAD_SERIALVERSIONUID" />
+			<Bug pattern="PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS" />
+			<Bug pattern="SPP_USELESS_TERNARY" />
+			<Bug pattern="SPP_TOSTRING_ON_STRING" />
+			<Bug pattern="USBR_UNNECESSARY_STORE_BEFORE_RETURN" />
+			<Bug pattern="AIOB_ARRAY_STORE_TO_NULL_REFERENCE" />
+			<Bug pattern="PMB_LOCAL_BASED_JAXB_CONTEXT" />
+			<Bug pattern="OI_OPTIONAL_ISSUES_ISPRESENT_PREFERRED" />
+			<Bug pattern="IOI_UNENDED_ZLIB_OBJECT" />
+			<Bug pattern="ENMI_ONE_ENUM_VALUE" />
+			<Bug pattern="ENMI_NULL_ENUM_VALUE" />
+			<Bug pattern="SPP_USE_BIGDECIMAL_STRING_CTOR" />
+			<Bug pattern="SAT_SUSPICIOUS_ARGUMENT_TYPES" />
+			<Bug pattern="MOM_MISLEADING_OVERLOAD_MODEL" />
+			<Bug pattern="EI_EXPOSE_BUF" />
+			<Bug
+				pattern="REFLF_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_FIELD" />
+			<Bug pattern="FL_FLOATS_AS_LOOP_COUNTERS" />
+			<Bug pattern="TLW_TWO_LOCK_NOTIFY" />
+			<Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+			<Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE" />
+			<Bug pattern="EI_EXPOSE_BUF2" />
+			<Bug pattern="OVERRIDING_METHODS_MUST_INVOKE_SUPER" />
+			<Bug pattern="BC_NULL_INSTANCEOF" />
+			<Bug pattern="SKIPPED_CLASS_TOO_BIG" />
+			<Bug pattern="RCN_REDUNDANT_CHECKED_NULL_COMPARISON" />
+			<Bug pattern="SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA" />
+			<Bug pattern="EI_EXPOSE_STATIC_BUF2" />
+			<Bug pattern="LG_LOST_LOGGER_DUE_TO_WEAK_REFERENCE" />
+			<Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION" />
+			<Bug pattern="LI_LAZY_INIT_INSTANCE" />
+			<Bug pattern="SE_NO_SERIALVERSIONID" />
+			<Bug
+				pattern="USC_POTENTIAL_SECURITY_CHECK_BASED_ON_UNTRUSTED_SOURCE" />
+			<Bug pattern="OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE" />
+			<Bug pattern="EI_EXPOSE_REP" />
+			<Bug pattern="PERM_SUPER_NOT_CALLED_IN_GETPERMISSIONS" />
+			<Bug pattern="DCN_NULLPOINTER_EXCEPTION" />
+			<Bug pattern="MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR" />
+			<Bug pattern="MC_OVERRIDABLE_METHOD_CALL_IN_CLONE" />
+			<Bug
+				pattern="REFLC_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_CLASS" />
+			<Bug pattern="BRSA_BAD_RESULTSET_ACCESS" />
+			<Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION" />
+			<Bug pattern="DP_DO_INSIDE_DO_PRIVILEDGED" />
+			<Bug pattern="EOS_BAD_END_OF_STREAM_CHECK" />
+			<Bug pattern="MS_EXPOSE_BUF" />
+			<Bug pattern="JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS" />
+			<Bug pattern="EI_EXPOSE_REP2" />
+			<Bug pattern="OBL_UNSATISFIED_OBLIGATION" />
+		</Or>
+	</Match>
+</FindBugsFilter>


### PR DESCRIPTION
This PR updates the build workflow to run on pushes to all branches and on pull-requests and to include static code analysis with SpotBugs and SonarCloud. An additional workflow is added for analysing PRs from forks with SonarCloud.

A profile "coverage" was added to the `pom.xml` of the module sapl-server-ce to run JaCoCo coverage analysis once unit tests are integrated. The build workflow includes an action to publish test results that can also be activated once unit tests are integrated.